### PR TITLE
modify completed todoItem link error

### DIFF
--- a/app/views/todo_list/index.erb
+++ b/app/views/todo_list/index.erb
@@ -237,7 +237,7 @@
                     <li ng-repeat="todoItem in todoList.todo_items | filter:isTodoCompletedFactory(true) | orderBy:'completed_at':true | limitTo:2 track by $index">
                       <input type="checkbox" ng-click="toggleTodoItem(todoItem)" ng-model="todoItem.completed" />
 
-                      <a href="{{ routes.show_issue|resolve:{':issue_id': todoItem.id} }}" ng-hide="todoItem.editMode.formVisible">
+                      <a href="{{ routes.show_issue|resolve:{':issue_id': todoItem.issue_id} }}" ng-hide="todoItem.editMode.formVisible">
                         <!--[#{{ todoItem.id }}]-->
                         {{ todoItem.subject }}
                       </a>


### PR DESCRIPTION
Hi,I found that every completed todoitem link is linked to a mistake issue in todolist index page, I modified todoItem.id to todoItem.issue_id, then the link is linked to correct position. 
