### PR TITLE
fixes mass assignment error for todo_item_id

### DIFF
--- a/app/models/todo_item.rb
+++ b/app/models/todo_item.rb
@@ -4,6 +4,8 @@ class TodoItem < ActiveRecord::Base
   has_one    :issue, :primary_key => "issue_id", :foreign_key => "id"
   acts_as_list
 
+  attr_accessible :todo_list_id
+
   def as_json(options=nil)
     {
         :id => self.id,


### PR DESCRIPTION
There is an mass assignment error on saving new Todo Items (here in the Rails 4 branch),
but it can be easily fixed.
(I dont't really understand how it ever worked on Rails 4, but I'm sure it did...).
